### PR TITLE
Export ValidationException

### DIFF
--- a/src/Validator/index.js
+++ b/src/Validator/index.js
@@ -11,6 +11,7 @@
 
 const indicative = require('indicative')
 const Validation = require('../Validation')
+const ValidationException = require('../Exceptions')
 
 module.exports = {
   validateAll: (...params) => new Validation(...params).runAll(),
@@ -19,5 +20,6 @@ module.exports = {
   rule: indicative.rule,
   is: indicative.is,
   sanitizor: indicative.sanitizor,
-  extend: indicative.extend
+  extend: indicative.extend,
+  ValidationException
 }

--- a/src/Validator/index.js
+++ b/src/Validator/index.js
@@ -11,7 +11,7 @@
 
 const indicative = require('indicative')
 const Validation = require('../Validation')
-const ValidationException = require('../Exceptions')
+const { ValidationException } = require('../Exceptions')
 
 module.exports = {
   validateAll: (...params) => new Validation(...params).runAll(),


### PR DESCRIPTION
The alternative, to throwing the exception manually, is:
`const ValidationException = require("@adonisjs/validator/src/Exceptions")`