### PR TITLE
Sanitize query params and body

### DIFF
--- a/src/Middleware/Validator.js
+++ b/src/Middleware/Validator.js
@@ -52,13 +52,17 @@ class ValidatorMiddleware {
       return true
     }
 
-    const data = request.all()
+    const qsData = request.get()
+    const sanitizedQSData = this.Validator.sanitize(qsData, validatorInstance.sanitizationRules)
+
+    const data = request.post()
     const sanitizedData = this.Validator.sanitize(data, validatorInstance.sanitizationRules)
 
     /**
-     * Here we mutate the actual request body, this is required since there is
+     * Here we mutate the actual request body and query params, this is required since there is
      * no point keep the actual data when we really want to sanitize it.
      */
+    request._qs = _.merge({}, qsData, sanitizedQSData)
     request.body = _.merge({}, data, sanitizedData)
   }
 

--- a/src/Middleware/Validator.js
+++ b/src/Middleware/Validator.js
@@ -52,7 +52,7 @@ class ValidatorMiddleware {
       return true
     }
 
-    const data = request.post()
+    const data = request.all()
     const sanitizedData = this.Validator.sanitize(data, validatorInstance.sanitizationRules)
 
     /**

--- a/test/validator-middleware.spec.js
+++ b/test/validator-middleware.spec.js
@@ -474,7 +474,7 @@ test.group('Validator Middleware', (group) => {
         }
         this._all = {}
         this._qs = {
-          age: 22
+          age: '22'
         }
       }
 
@@ -507,7 +507,8 @@ test.group('Validator Middleware', (group) => {
     class UserValidator {
       get sanitizationRules () {
         return {
-          email: 'normalize_email'
+          email: 'normalize_email',
+          age: 'to_int'
         }
       }
     }
@@ -515,6 +516,7 @@ test.group('Validator Middleware', (group) => {
     ioc.fake('App/Validators/User', () => new UserValidator())
     await middleware.handle({ request }, next, ['App/Validators/User'])
     assert.equal(request.all().email, 'foo@gmail.com')
+    assert.strictEqual(request.all().age, 22)
   })
 
   test('use data defined on validator instance', async (assert) => {


### PR DESCRIPTION
Actually when try to sanitize query params from Route Validator doesn't work