### PR TITLE
feat: RegExp validation rule

### DIFF
--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -475,6 +475,11 @@ declare module '@ioc:Adonis/Core/Validator' {
      * String must be alpha
      */
     alpha (): Rule
+
+    /**
+     * String must match regex
+     */
+    regex (regexPattern: RegExp): Rule
     email (options?: EmailRuleOptions): Rule
     ip (options?: { version?: '4' | '6' }): Rule
     mobile (optioms?: { strict?: boolean, locale?: validatorJs.MobilePhoneLocale[] }): Rule

--- a/src/Validations/index.ts
+++ b/src/Validations/index.ts
@@ -29,6 +29,7 @@ export { object } from './primitives/object'
 export { string } from './primitives/string'
 
 export { alpha } from './string/alpha'
+export { regex } from './string/regex'
 export { email } from './string/email'
 export { ip } from './string/ip'
 export { mobile } from './string/mobile'

--- a/src/Validations/string/regex.ts
+++ b/src/Validations/string/regex.ts
@@ -1,0 +1,48 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+import { SyncValidation } from '@ioc:Adonis/Core/Validator'
+import { ensureValidArgs } from '../../Validator/helpers'
+
+const DEFAULT_MESSAGE = 'regex validation failed'
+const RULE_NAME = 'regex'
+
+/**
+ * Validation signature for the "alpha" regex. Non-string values are
+ * ignored.
+ */
+export const regex: SyncValidation<{regexPattern: RegExp}> = {
+  compile (_, subtype, args) {
+    ensureValidArgs(RULE_NAME, args)
+    const [regexPattern] = args
+    if (subtype !== 'string') {
+      throw new Error(`Cannot use regex rule on "${subtype}" data type.`)
+    }
+
+    return {
+      allowUndefineds: false,
+      async: false,
+      name: RULE_NAME,
+      compiledOptions: { regexPattern },
+    }
+  },
+  validate (value, { regexPattern }, { errorReporter, arrayExpressionPointer, pointer }) {
+    /**
+     * Ignore non-string values. The user must apply string rule
+     * to validate string
+     */
+    if (typeof (value) !== 'string') {
+      return
+    }
+
+    if (!regexPattern.test(value)) {
+      errorReporter.report(pointer, RULE_NAME, DEFAULT_MESSAGE, arrayExpressionPointer)
+    }
+  },
+}

--- a/test/validations/regex.spec.ts
+++ b/test/validations/regex.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+*/
+
+import test from 'japa'
+
+import { rules } from '../../src/Rules'
+import { validate } from '../fixtures/rules/index'
+import { ApiErrorReporter } from '../../src/ErrorReporter'
+import { regex } from '../../src/Validations/string/regex'
+
+function compile () {
+  // Regex Example for tax id validation from Brazil
+  return regex.compile('literal', 'string', rules.regex(
+    /(^\d{3}.\d{3}.\d{3}-\d{2}$|^\d{11}$|^\d{14}$|^\d{2}.\d{3}.\d{3}\/\d{4}-\d{2}$)/gm)
+    .options)
+}
+
+test.group('Regex', () => {
+  validate(regex, test, '9999', '99.999.999/0001-99', compile())
+
+  test('ignore validation when value is not a valid string', (assert) => {
+    const reporter = new ApiErrorReporter({}, false)
+    regex.validate(null, compile().compiledOptions, {
+      errorReporter: reporter,
+      field: 'username',
+      pointer: 'username',
+      tip: {},
+      root: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), [])
+  })
+
+  test('report error when value fails the regex pattern', (assert) => {
+    const reporter = new ApiErrorReporter({}, false)
+    regex.validate('999999990001', compile().compiledOptions, {
+      errorReporter: reporter,
+      field: 'username',
+      pointer: 'username',
+      tip: {},
+      root: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), [{
+      field: 'username',
+      rule: 'regex',
+      message: 'regex validation failed',
+    }])
+  })
+
+  test('work fine when value passes the regex pattern', (assert) => {
+    const reporter = new ApiErrorReporter({}, false)
+    regex.validate('99.999.999/0001-99', compile().compiledOptions, {
+      errorReporter: reporter,
+      field: 'username',
+      pointer: 'username',
+      tip: {},
+      root: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), [])
+  })
+})


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Added a custome Rule where you can pass a RegExp to be used as validator, allowing the user to build any type of string validator he needs.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I just built this new rule based on two already existing rules: `alpha` and `max-length`. The rule alpha already uses a regexp validation rule, but the rule is built-in it. So I used the same logic to receive "args" from `max-length` Rule to receive a RegExp pattern and use it instead of a hard codeded RegExp.
For the tests I used a common RegExp used in Brazil to validate Tax Id Number for both Natural Person and Legal Person.
