### PR TITLE
fix: Add 'true' and 'false' to boolean value (#86)

### DIFF
--- a/src/Validations/primitives/boolean.ts
+++ b/src/Validations/primitives/boolean.ts
@@ -11,8 +11,8 @@ import { SyncValidation } from '@ioc:Adonis/Core/Validator'
 import { wrapCompile } from '../../Validator/helpers'
 
 const RULE_NAME = 'boolean'
-const BOOLEAN_POSITIVES = [ '1', 1, 'on' ]
-const BOOLEAN_NEGATIVES = [ '0', 0, 'off' ]
+const BOOLEAN_POSITIVES = [ '1', 1, 'on', 'true' ]
+const BOOLEAN_NEGATIVES = [ '0', 0, 'off', 'false' ]
 const DEFAULT_MESSAGE = 'boolean validation failed'
 
 /**

--- a/test/validations/boolean.spec.ts
+++ b/test/validations/boolean.spec.ts
@@ -162,6 +162,46 @@ test.group('boolean', () => {
     assert.equal(value, false)
   })
 
+  test('cast true keyword to a positive boolean', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    let value: any = 'true'
+
+    boolean.validate(value, compile().compiledOptions, {
+      errorReporter: reporter,
+      field: 'terms',
+      pointer: 'terms',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: (newValue) => {
+        value = newValue
+      },
+    })
+
+    assert.deepEqual(reporter.toJSON(), { errors: [] })
+    assert.equal(value, true)
+  })
+
+  test('cast false keyword to a negative boolean', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    let value: any = 'false'
+
+    boolean.validate(value, compile().compiledOptions, {
+      errorReporter: reporter,
+      field: 'terms',
+      pointer: 'terms',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: (newValue) => {
+        value = newValue
+      },
+    })
+
+    assert.deepEqual(reporter.toJSON(), { errors: [] })
+    assert.equal(value, false)
+  })
+
   test('work fine when value is a positive boolean', (assert) => {
     const reporter = new ApiErrorReporter(new MessagesBag({}), false)
     let value: any = true


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

It should be added because edge template receive 'true' or 'false' as value when doing this :
Controller.ts
```
const myObjectWithBoolean = await MyObjectWithBoolean.query()....firstOrFail() //{myBoolean: true}
return view.render('myView', {...myObjectWithBoolean.toJSON()})
```

view.edge
`<p>{{myBoolean}}</p>  => display 'true', not 1, '1' or 'on'`

eg.
```
<div x-data="{ showMessage: {{show_message}} }">
  <input type="checkbox" x-model="showMessage">
  <input type="hidden" name="showMessage" :value="showMessage">
</div>
```

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

/
