### PR TITLE
Fix for refs being undefined in validation function

### DIFF
--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            August 9th 2020, 3:39:10 pm
+                            August 12th 2020, 7:47:51 am
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/Compiler/index.ts
+++ b/src/Compiler/index.ts
@@ -238,7 +238,7 @@ export class Compiler {
 		 * - `exists` checks whether the value is defined or not.
 		 */
 		buffer.wrappingCode([
-			'return async function (root, validations, errorReporter, helpers, validator) {',
+			'return async function (root, validations, errorReporter, helpers, refs) {',
 			'}',
 		])
 
@@ -277,13 +277,6 @@ export class Compiler {
 	 * Compiles the schema tree to an executable function
 	 */
 	public compile<T extends any>(): CompilerOutput<T> {
-		return new Function(
-			'root',
-			'validations',
-			'errorReporter',
-			'helpers',
-			'refs',
-			this.compileAsString()
-		)()
+		return new Function(this.compileAsString())()
 	}
 }

--- a/test/validator.spec.ts
+++ b/test/validator.spec.ts
@@ -177,6 +177,67 @@ test.group('Validator | rule', () => {
 		})
 	})
 
+	test('rule recieves correct arguments', async (assert) => {
+		assert.plan(14)
+
+		const name = 'testArguments'
+
+		const refs = schema.refs({
+			username: 'ruby',
+		})
+
+		const options = [
+			{
+				operator: '=',
+			},
+		]
+
+		const data = {
+			users: ['virk'],
+		}
+
+		validator.rule(
+			name,
+			(value, compiledOptions, runtimeOptions) => {
+				assert.equal(value, 'virk')
+				assert.deepEqual(compiledOptions, options)
+				assert.hasAllKeys(runtimeOptions, [
+					'root',
+					'tip',
+					'field',
+					'pointer',
+					'arrayExpressionPointer',
+					'refs',
+					'errorReporter',
+					'mutate',
+				])
+				assert.deepEqual(runtimeOptions.root, data)
+				assert.deepEqual(runtimeOptions.tip, ['virk'])
+				assert.equal(runtimeOptions.field, '0')
+				assert.equal(runtimeOptions.pointer, 'users.0')
+				assert.equal(runtimeOptions.arrayExpressionPointer, 'users.*')
+				assert.deepEqual(runtimeOptions.refs, refs)
+				assert.instanceOf(runtimeOptions.errorReporter, ApiErrorReporter)
+				assert.isFunction(runtimeOptions.mutate)
+			},
+			(opts, type, subtype) => {
+				assert.deepEqual(opts, options)
+				assert.equal(type, 'literal')
+				assert.equal(subtype, 'string')
+				return {}
+			}
+		)
+
+		await validator.validate({
+			refs,
+			schema: schema.create({
+				users: schema.array().members(schema.string({}, [{ name, options }])),
+			}),
+			data,
+			reporter: ApiErrorReporter,
+		})
+	})
+
 	test('set allowUndefineds to true', (assert) => {
 		validator.rule(
 			'isPhone',


### PR DESCRIPTION
## Proposed changes

Refs are not passed to validation function due to incorrect name `validator` of parameter which is accepted by compiled wrapping function which should be `refs`:

```javascript
return async function (root, validations, errorReporter, helpers, validator) {
```

In validation runtimeOptions `refs` are referenced and because of name mismatch it is undefined.

```javascript
return `const ${this.getVariableOptionsName(variableName)} = {
	root,
	refs,
	field: ${field},
	tip: ${tip},
	pointer: ${pointer},${arrayExpressionPointerItem}
	mutate: ${this.getVariableMutationName(variableName)},
	${this.COMPILER_REFERENCES.reportError}
}`
```
Also I have removed unneeded arguments in compile function because it does not take any arguments - it is called straight away and is returning async function mentioned above where are the arguments names.

I have also added test for arguments passed to compile and validation functions in rule.
## Types of changes
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

