### PR TITLE
feat: added afterOrEqualTo & beforeOrEqualTo rules for date

### DIFF
--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -729,6 +729,11 @@ declare module '@ioc:Adonis/Core/Validator' {
 		afterOrEqualToField(field: string): Rule
 
 		/**
+		 * The value of date must be after or equal a given date
+		 */
+		afterOrEqualTo(otherValue: SchemaRef<DateTime>): Rule
+
+		/**
 		 * The value of date must be before a given date
 		 */
 		beforeField(field: string): Rule
@@ -737,6 +742,11 @@ declare module '@ioc:Adonis/Core/Validator' {
 		 * The value of date must be before or equal to a given date
 		 */
 		beforeOrEqualToField(field: string): Rule
+
+		/**
+		 * The value of date must be before or equal a given date
+		 */
+		beforeOrEqualTo(otherValue: SchemaRef<DateTime>): Rule
 
 		/**
 		 * Blacklist an array of values

--- a/npm-audit.html
+++ b/npm-audit.html
@@ -55,7 +55,7 @@
                 <div class="card">
                     <div class="card-body">
                         <h5 class="card-title">
-                            August 27th 2020, 2:22:31 pm
+                            August 29th 2020, 5:06:09 pm
                         </h5>
                         <p class="card-text">Last updated</p>
                     </div>

--- a/src/Validations/date/afterOrEqualTo.ts
+++ b/src/Validations/date/afterOrEqualTo.ts
@@ -1,0 +1,27 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { SyncValidation } from '@ioc:Adonis/Core/Validator'
+import { compile, validate, CompileReturnType } from './helpers/compare'
+import { wrapCompile } from '../../Validator/helpers'
+
+const RULE_NAME = 'afterOrEqualTo'
+const DEFAULT_MESSAGE = 'after or equal to date validation failed'
+
+/**
+ * Ensure the value is one of the defined choices
+ */
+export const afterOrEqualTo: SyncValidation<CompileReturnType> = {
+	compile: wrapCompile<CompileReturnType>(RULE_NAME, ['date'], (options: any[]) => {
+		return compile(RULE_NAME, '>=', options)
+	}),
+	validate(value, compiledOptions, runtimeOptions) {
+		return validate(RULE_NAME, DEFAULT_MESSAGE, value, compiledOptions, runtimeOptions)
+	},
+}

--- a/src/Validations/date/beforeOrEqualTo.ts
+++ b/src/Validations/date/beforeOrEqualTo.ts
@@ -1,0 +1,27 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { SyncValidation } from '@ioc:Adonis/Core/Validator'
+import { compile, validate, CompileReturnType } from './helpers/compare'
+import { wrapCompile } from '../../Validator/helpers'
+
+const RULE_NAME = 'beforeOrEqualTo'
+const DEFAULT_MESSAGE = 'before or equal to date validation failed'
+
+/**
+ * Ensure the value is one of the defined choices
+ */
+export const beforeOrEqualTo: SyncValidation<CompileReturnType> = {
+	compile: wrapCompile<CompileReturnType>(RULE_NAME, ['date'], (options: any[]) => {
+		return compile(RULE_NAME, '<=', options)
+	}),
+	validate(value, compiledOptions, runtimeOptions) {
+		return validate(RULE_NAME, DEFAULT_MESSAGE, value, compiledOptions, runtimeOptions)
+	},
+}

--- a/src/Validations/date/helpers/compare.ts
+++ b/src/Validations/date/helpers/compare.ts
@@ -1,0 +1,91 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { DateTime } from 'luxon'
+import { ValidationRuntimeOptions } from '@ioc:Adonis/Core/Validator'
+import { isRef, enforceDateTime } from '../../../Validator/helpers'
+
+/**
+ * Return type of the compile function
+ */
+export type CompileReturnType = {
+	operator: '>=' | '<='
+	ref: string
+}
+
+/**
+ * Returns a luxon date time instance based upon the unit, duration and operator
+ */
+
+/**
+ * Returns a luxon date time instance based upon the unit, duration and operator
+ */
+function compareDateTime(lhs: DateTime, rhs: DateTime, operator: '>=' | '<=') {
+	return operator === '>=' ? lhs >= rhs : lhs <= rhs
+}
+
+/**
+ * Compiles an offset based date rule
+ */
+export function compile(
+	ruleName: string,
+	operator: '>=' | '<=',
+	[otherValue]: any
+): { compiledOptions: CompileReturnType } {
+	/**
+	 * Choices are defined as a ref
+	 */
+	if (!isRef(otherValue)) {
+		throw new Error(`"${ruleName}": expects value to be a ref of type DateTime`)
+	}
+
+	return {
+		compiledOptions: { ref: otherValue.key, operator },
+	}
+}
+
+/**
+ * Validates offset based date rules
+ */
+export function validate(
+	ruleName: string,
+	errorMessage: string,
+	value: any,
+	compiledOptions: CompileReturnType,
+	{ errorReporter, pointer, arrayExpressionPointer, refs }: ValidationRuntimeOptions
+) {
+	let comparisonDate: DateTime | unknown
+
+	/**
+	 * Do not run validation when original value is not a dateTime instance.
+	 */
+	if (value instanceof DateTime === false) {
+		return
+	}
+
+	/**
+	 * Resolve datetime to compare against
+	 */
+	comparisonDate = refs[compiledOptions.ref].value
+
+	if (!comparisonDate) {
+		return
+	}
+
+	enforceDateTime(
+		comparisonDate,
+		`"${ruleName}": expects "refs.${compiledOptions.ref}" to be an date`
+	)
+
+	if (!compareDateTime(value, comparisonDate, compiledOptions.operator)) {
+		errorReporter.report(pointer, ruleName, errorMessage, arrayExpressionPointer, {
+			[ruleName]: comparisonDate.toISO(),
+		})
+	}
+}

--- a/src/Validations/index.ts
+++ b/src/Validations/index.ts
@@ -12,10 +12,12 @@ export { distinct } from './array/distinct'
 export { after } from './date/after'
 export { afterField } from './date/afterField'
 export { afterOrEqualToField } from './date/afterOrEqualToField'
+export { afterOrEqualTo } from './date/afterOrEqualTo'
 
 export { before } from './date/before'
 export { beforeField } from './date/beforeField'
 export { beforeOrEqualToField } from './date/beforeOrEqualToField'
+export { beforeOrEqualTo } from './date/beforeOrEqualTo'
 
 export { confirmed } from './existence/confirmed'
 export { required } from './existence/required'

--- a/test/validations/after-or-equal-to.spec.ts
+++ b/test/validations/after-or-equal-to.spec.ts
@@ -1,0 +1,234 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import test from 'japa'
+import { DateTime } from 'luxon'
+import { SchemaRef, ParsedRule } from '@ioc:Adonis/Core/Validator'
+
+import { rules } from '../../src/Rules'
+import { schema } from '../../src/Schema'
+import { MessagesBag } from '../../src/MessagesBag'
+import { ApiErrorReporter } from '../../src/ErrorReporter'
+import { afterOrEqualTo } from '../../src/Validations/date/afterOrEqualTo'
+
+function compile(date: SchemaRef<DateTime>): ParsedRule<any> {
+	return afterOrEqualTo.compile('literal', 'date', rules.afterOrEqualTo(date).options, {})
+}
+
+test.group('Date | AfterOrEqualTo | Ref', () => {
+	test('report error when date is before the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().toISODate()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().plus({ days: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 1)
+		assert.equal(errors.errors[0].field, 'published_at')
+		assert.equal(errors.errors[0].rule, 'afterOrEqualTo')
+		assert.equal(errors.errors[0].message, 'after or equal to date validation failed')
+	})
+
+	test('report error when datetime is before the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().toISO()
+
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().plus({ minutes: 30 }),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 1)
+		assert.equal(errors.errors[0].field, 'published_at')
+		assert.equal(errors.errors[0].rule, 'afterOrEqualTo')
+		assert.equal(errors.errors[0].message, 'after or equal to date validation failed')
+	})
+
+	test('report error when time is not defined for the same day', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().plus({ minutes: 30 }).toISODate()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().plus({ minutes: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 1)
+		assert.equal(errors.errors[0].field, 'published_at')
+		assert.equal(errors.errors[0].rule, 'afterOrEqualTo')
+		assert.equal(errors.errors[0].message, 'after or equal to date validation failed')
+	})
+
+	test('work fine when date is after the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().plus({ days: 11 }).toISODate()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().plus({ days: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when datetime is after the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().plus({ minutes: 30 }).toISO()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().plus({ minutes: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when time is not defined for the next day', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().plus({ days: 1 }).toISODate()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().plus({ minutes: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when time is not defined for the next day date case', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().startOf('day').toISODate()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().startOf('day'),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when time is not defined for the next day datetime case', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().startOf('day').toISO()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().startOf('day'),
+			}),
+			mutate: () => {},
+		}
+
+		afterOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+})

--- a/test/validations/before-or-equal-to.spec.ts
+++ b/test/validations/before-or-equal-to.spec.ts
@@ -1,0 +1,236 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import test from 'japa'
+import { DateTime } from 'luxon'
+import { SchemaRef, ParsedRule } from '@ioc:Adonis/Core/Validator'
+
+import { rules } from '../../src/Rules'
+import { schema } from '../../src/Schema'
+import { MessagesBag } from '../../src/MessagesBag'
+import { ApiErrorReporter } from '../../src/ErrorReporter'
+import { beforeOrEqualTo } from '../../src/Validations/date/beforeOrEqualTo'
+
+function compile(date: SchemaRef<DateTime>): ParsedRule<any> {
+	return beforeOrEqualTo.compile('literal', 'date', rules.beforeOrEqualTo(date).options, {})
+}
+
+test.group('Date | BeforeOrEqualTo | Ref', () => {
+	test('report error when date is not before the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().toISODate()
+
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				beforeDate: DateTime.local().minus({ days: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.beforeDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 1)
+		assert.equal(errors.errors[0].field, 'published_at')
+		assert.equal(errors.errors[0].rule, 'beforeOrEqualTo')
+		assert.equal(errors.errors[0].message, 'before or equal to date validation failed')
+	})
+
+	test('report error when datetime is not before the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().toISO()
+
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				beforeDate: DateTime.local().minus({ minutes: 30 }),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.beforeDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 1)
+		assert.equal(errors.errors[0].field, 'published_at')
+		assert.equal(errors.errors[0].rule, 'beforeOrEqualTo')
+		assert.equal(errors.errors[0].message, 'before or equal to date validation failed')
+	})
+
+	test('work fine when time is not defined for the same day', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().minus({ minutes: 5 }).toISODate()
+
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				beforeDate: DateTime.local().minus({ minutes: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.beforeDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when date is before the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().minus({ days: 11 }).toISODate()
+
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				beforeDate: DateTime.local().minus({ days: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.beforeDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when datetime is before the defined ref', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().minus({ minutes: 30 }).toISO()
+
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				beforeDate: DateTime.local().minus({ minutes: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.beforeDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when time is not defined for the previous day', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().minus({ days: 1 }).toISODate()
+
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				beforeDate: DateTime.local().minus({ minutes: 10 }),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.beforeDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when time is not defined for the next day date case', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().startOf('day').toISODate()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().startOf('day'),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+
+	test('work fine when time is not defined for the next day datetime case', (assert) => {
+		const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+		const publishedAt = DateTime.local().startOf('day').toISO()
+		const validator = {
+			errorReporter: reporter,
+			field: 'published_at',
+			pointer: 'published_at',
+			tip: {},
+			root: {},
+			refs: schema.refs({
+				afterDate: DateTime.local().startOf('day'),
+			}),
+			mutate: () => {},
+		}
+
+		beforeOrEqualTo.validate(
+			DateTime.fromISO(publishedAt!),
+			compile(validator.refs.afterDate).compiledOptions!,
+			validator
+		)
+
+		const errors = reporter.toJSON()
+		assert.lengthOf(errors.errors, 0)
+	})
+})


### PR DESCRIPTION
## Proposed changes

Added afterOrEqualTo and beforeOrEqualTo rules for dates so that you can use refs the same way the [after,before]OrEqualToField rules work.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
