### PR TITLE
feat: Add beforeOrEqual & afterOrEqual validators

### DIFF
--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -952,6 +952,42 @@ declare module '@ioc:Adonis/Core/Validator' {
      * The value of string must be equalToValue
      */
     equalTo(equalToValue: string | SchemaRef<string>): Rule
+
+    /**
+     * The value of date must be after or equal to a given duration
+     */
+    afterOrEqual(duration: number, unit: DurationUnits): Rule
+
+    /**
+     * The value of date must be after or equal to a given date
+     */
+    afterOrEqual(date: SchemaRef<DateTime>): Rule
+
+    /**
+     * The value of date must be after or equal to the given keyword.
+     *
+     * After "today" is equivalent to 0, days
+     * After "tomorrow" is equivalent to 1, day
+     */
+    afterOrEqual(keyword: 'today' | 'tomorrow'): Rule
+
+    /**
+     * The value of date must be before or equal to a given duration
+     */
+    beforeOrEqual(duration: number, unit: DurationUnits): Rule
+
+    /**
+     * The value of date must be before or equal to a given date
+     */
+    beforeOrEqual(date: SchemaRef<DateTime>): Rule
+
+    /**
+     * The value of date must be before or equal to the given keyword.
+     *
+     * Before "today" is equivalent to 0, days
+     * Before "yesterday" is equivalent to 1, day
+     */
+    beforeOrEqual(keyword: 'today' | 'yesterday'): Rule
   }
 
   /**

--- a/src/Validations/date/afterOrEqual.ts
+++ b/src/Validations/date/afterOrEqual.ts
@@ -1,0 +1,27 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { SyncValidation } from '@ioc:Adonis/Core/Validator'
+import { wrapCompile } from '../../Validator/helpers'
+import { compile, validate, CompileReturnType } from './helpers/offset'
+
+const RULE_NAME = 'afterOrEqual'
+const DEFAULT_MESSAGE = 'afterOrEqual date validation failed'
+
+/**
+ * Ensure the value is one of the defined choices
+ */
+export const afterOrEqual: SyncValidation<CompileReturnType> = {
+  compile: wrapCompile<CompileReturnType>(RULE_NAME, ['date'], (options: any[]) => {
+    return compile(RULE_NAME, '>=', options)
+  }),
+  validate(value, compiledOptions, runtimeOptions) {
+    return validate(RULE_NAME, DEFAULT_MESSAGE, value, compiledOptions, runtimeOptions)
+  },
+}

--- a/src/Validations/date/beforeOrEqual.ts
+++ b/src/Validations/date/beforeOrEqual.ts
@@ -1,0 +1,27 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import { SyncValidation } from '@ioc:Adonis/Core/Validator'
+import { compile, validate, CompileReturnType } from './helpers/offset'
+import { wrapCompile } from '../../Validator/helpers'
+
+const RULE_NAME = 'beforeOrEqual'
+const DEFAULT_MESSAGE = 'beforeOrEqual date validation failed'
+
+/**
+ * Ensure the value is one of the defined choices
+ */
+export const beforeOrEqual: SyncValidation<CompileReturnType> = {
+  compile: wrapCompile<CompileReturnType>(RULE_NAME, ['date'], (options: any[]) => {
+    return compile(RULE_NAME, '<=', options)
+  }),
+  validate(value, compiledOptions, runtimeOptions) {
+    return validate(RULE_NAME, DEFAULT_MESSAGE, value, compiledOptions, runtimeOptions)
+  },
+}

--- a/src/Validations/date/helpers/offset.ts
+++ b/src/Validations/date/helpers/offset.ts
@@ -15,7 +15,7 @@ import { isRef, enforceDateTime } from '../../../Validator/helpers'
  * Return type of the compile function
  */
 export type CompileReturnType = {
-  operator: '>' | '<'
+  operator: '>' | '<' | '>=' | '<='
   offset?: { duration: number; unit: DurationUnits; hasDayDuration: boolean }
   ref?: string
 }
@@ -24,10 +24,10 @@ export type CompileReturnType = {
  * Returns a luxon date time instance based upon the unit, duration and operator
  */
 function getDateTime(
-  operator: '>' | '<',
+  operator: '>' | '<' | '>=' | '<=',
   { unit, duration }: Exclude<CompileReturnType['offset'], undefined>
 ) {
-  if (operator === '>') {
+  if (operator === '>' || operator === '>=') {
     return DateTime.local().plus({ [unit]: duration })
   }
   return DateTime.local().minus({ [unit]: duration })
@@ -39,15 +39,30 @@ function getDateTime(
 function compareDateTime(
   lhs: DateTime,
   rhs: DateTime,
-  operator: '>' | '<',
+  operator: '>' | '<' | '>=' | '<=',
   options: CompileReturnType['offset']
 ) {
   if (options && options.hasDayDuration) {
-    return operator === '>'
-      ? lhs.startOf('day') > rhs.startOf('day')
-      : lhs.startOf('day') < rhs.startOf('day')
+    if (operator === '>') {
+      return lhs.startOf('day') > rhs.startOf('day')
+    } else if (operator === '>=') {
+      return lhs.startOf('day') >= rhs.startOf('day')
+    } else if (operator === '<') {
+      return lhs.startOf('day') < rhs.startOf('day')
+    } else if (operator === '<=') {
+      return lhs.startOf('day') <= rhs.startOf('day')
+    }
   }
-  return operator === '>' ? lhs > rhs : lhs < rhs
+
+  if (operator === '>') {
+    return lhs > rhs
+  } else if (operator === '>=') {
+    return lhs >= rhs
+  } else if (operator === '<') {
+    return lhs < rhs
+  } else if (operator === '<=') {
+    return lhs <= rhs
+  }
 }
 
 /**
@@ -55,7 +70,7 @@ function compareDateTime(
  */
 export function compile(
   ruleName: string,
-  operator: '>' | '<',
+  operator: '>' | '<' | '>=' | '<=',
   [duration, unit]: any[]
 ): { compiledOptions: CompileReturnType } {
   /**

--- a/src/Validations/index.ts
+++ b/src/Validations/index.ts
@@ -10,10 +10,12 @@
 export { distinct } from './array/distinct'
 
 export { after } from './date/after'
+export { afterOrEqual } from './date/afterOrEqual'
 export { afterField } from './date/afterField'
 export { afterOrEqualToField } from './date/afterOrEqualToField'
 
 export { before } from './date/before'
+export { beforeOrEqual } from './date/beforeOrEqual'
 export { beforeField } from './date/beforeField'
 export { beforeOrEqualToField } from './date/beforeOrEqualToField'
 

--- a/test/validations/after-or-equal.spec.ts
+++ b/test/validations/after-or-equal.spec.ts
@@ -295,7 +295,24 @@ test.group('Date | After Or Equal | Minutes', () => {
   test('work fine when time is after or equal to the defined interval', (assert) => {
     const reporter = new ApiErrorReporter(new MessagesBag({}), false)
     const publishedAt = DateTime.local().plus({ minutes: 40 }).toISO()
-    const publishedAtSameTime = DateTime.local().plus({ minutes: 30 }).toISO()
+
+    /*
+    Incrementing minutes only with .plus() with make this test fails because its milliseconds and seconds will always lesser than
+    the one that produce in "src/Validations/date/helpers/offset.ts". Hence, setting the max seconds and milliseconds to force
+    this test compares equality in minutes only.
+    */
+    const local = DateTime.local()
+    const publishedAtSameTime = DateTime.local(
+      local.year,
+      local.month,
+      local.day,
+      local.hour,
+      local.minute,
+      59,
+      999
+    )
+      .plus({ minutes: 30 })
+      .toISO()
 
     afterOrEqual.validate(DateTime.fromISO(publishedAt!), compile(30, 'minutes').compiledOptions!, {
       errorReporter: reporter,

--- a/test/validations/after-or-equal.spec.ts
+++ b/test/validations/after-or-equal.spec.ts
@@ -1,0 +1,529 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import test from 'japa'
+import { DateTime } from 'luxon'
+import { SchemaRef, ParsedRule, DurationUnits } from '@ioc:Adonis/Core/Validator'
+
+import { rules } from '../../src/Rules'
+import { schema } from '../../src/Schema'
+import { validate } from '../fixtures/rules/index'
+import { MessagesBag } from '../../src/MessagesBag'
+import { ApiErrorReporter } from '../../src/ErrorReporter'
+import { afterOrEqual } from '../../src/Validations'
+
+function compile(keyword: 'today' | 'tomorrow'): ParsedRule<any>
+// eslint-disable-next-line no-redeclare
+function compile(date: SchemaRef<DateTime>): ParsedRule<any>
+// eslint-disable-next-line no-redeclare
+function compile(interval: number, duration: DurationUnits): ParsedRule<any>
+// eslint-disable-next-line no-redeclare
+function compile(
+  interval: number | SchemaRef<DateTime> | 'today' | 'tomorrow',
+  duration?: DurationUnits
+): ParsedRule<any> {
+  const { options } =
+    typeof interval === 'number'
+      ? rules.afterOrEqual(interval, duration!)
+      : typeof interval === 'string'
+      ? rules.afterOrEqual(interval)
+      : rules.afterOrEqual(interval)
+
+  return afterOrEqual.compile('literal', 'date', options)
+}
+
+test.group('Date | After Or Equal', () => {
+  validate(
+    afterOrEqual,
+    test,
+    DateTime.local(),
+    DateTime.local().plus({ days: 2 }),
+    compile(1, 'day'),
+    {}
+  )
+
+  test('do not compile when one argument is passed and is not a ref', (assert) => {
+    const fn = () => afterOrEqual.compile('literal', 'date', ['foo'])
+    assert.throw(fn, '"afterOrEqual": expects a date offset "duration" and "unit" or a "ref"')
+  })
+
+  test('do not compile when interval is not a number', (assert) => {
+    const fn = () => afterOrEqual.compile('literal', 'date', ['foo', 'days'])
+    assert.throw(fn, '"afterOrEqual": expects "duration" to be a number')
+  })
+
+  test('do not compile when interval no arguments are defined', (assert) => {
+    const fn = () => afterOrEqual.compile('literal', 'date', [])
+    assert.throw(fn, '"afterOrEqual": expects a date offset "duration" and "unit" or a "ref"')
+  })
+})
+
+test.group('Date | After Or Equal | Day', () => {
+  test('report error when date is not after or equal to defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().toISODate()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedOn!), compile(1, 'day').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('report error when datetime is not after or equal to defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().minus({ days: 1 }).toISO()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedOn!), compile(1, 'day').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('work fine when date is after or equal to defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().plus({ days: 2 }).toISO()
+    const publishedOnSameDate = DateTime.local().plus({ days: 1 }).toISO()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedOn!), compile(1, 'day').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedOnSameDate!),
+      compile(1, 'day').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_on',
+        pointer: 'published_on',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('return error when date is not after or equal to today', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().minus({ day: 1 }).toISODate()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedOn!), compile('today').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('work fine when date is after or equal to today', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().plus({ days: 1 }).toISODate()
+    const publishedOnSameDate = DateTime.local().toISODate()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedOn!), compile('today').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedOnSameDate!),
+      compile('today').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_on',
+        pointer: 'published_on',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('return error when date is not after or equal to tomorrow', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().toISODate()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedOn!), compile('tomorrow').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('work fine when date is after or equal to tomorrow', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().plus({ days: 2 }).toISODate()
+    const publishedOnTomorrow = DateTime.local().plus({ days: 1 }).toISODate()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedOn!), compile('tomorrow').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedOnTomorrow!),
+      compile('tomorrow').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_on',
+        pointer: 'published_on',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+})
+
+test.group('Date | After Or Equal | Minutes', () => {
+  test('report error when time is not defined for the same day', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISODate()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedAt!), compile(30, 'minutes').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('report error when time is not after or equal to the defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISO()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedAt!), compile(30, 'minutes').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('work fine when time is after or equal to the defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().plus({ minutes: 40 }).toISO()
+    const publishedAtSameTime = DateTime.local().plus({ minutes: 30 }).toISO()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedAt!), compile(30, 'minutes').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAtSameTime!),
+      compile(30, 'minutes').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_at',
+        pointer: 'published_at',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('work fine when time is not defined for next day', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().plus({ days: 1 }).toISODate()
+
+    afterOrEqual.validate(DateTime.fromISO(publishedAt!), compile(30, 'minutes').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+})
+
+test.group('Date | After Or Equal | Ref', () => {
+  test('report error when date is before the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISODate()
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        afterDate: DateTime.local().plus({ days: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('report error when datetime is before the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISO()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        afterDate: DateTime.local().plus({ minutes: 30 }),
+      }),
+      mutate: () => {},
+    }
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('report error when time is not defined for the same day', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().plus({ minutes: 30 }).toISODate()
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        afterDate: DateTime.local().plus({ minutes: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'afterOrEqual')
+    assert.equal(errors.errors[0].message, 'afterOrEqual date validation failed')
+  })
+
+  test('work fine when date is after or equal to the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().plus({ days: 11 }).toISODate()
+
+    /* 
+      Using toISO because toISODate will not include hours, minutes, seconds, ...
+      So if later when it get converted to datetime again, the test will fail 
+      because `publishedAtSameDate` would then have 0 in hours, minutes, seconds, ... but datetime in ref is not.
+    */
+    const publishedAtSameDate = DateTime.local().plus({ days: 10 }).toISO()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        afterDate: DateTime.local().plus({ days: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAtSameDate),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('work fine when datetime is after or equal to the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().plus({ minutes: 30 }).toISO()
+    const publishedAtSameDateTime = DateTime.local().plus({ minutes: 10 }).toISO()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        afterDate: DateTime.local().plus({ minutes: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAtSameDateTime!),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('work fine when time is not defined for the next day', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().plus({ days: 1 }).toISODate()
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        afterDate: DateTime.local().plus({ minutes: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    afterOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.afterDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+})

--- a/test/validations/before-or-equal.spec.ts
+++ b/test/validations/before-or-equal.spec.ts
@@ -1,0 +1,538 @@
+/*
+ * @adonisjs/validator
+ *
+ * (c) Harminder Virk <virk@adonisjs.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+import test from 'japa'
+import { DateTime } from 'luxon'
+import { SchemaRef, ParsedRule, DurationUnits } from '@ioc:Adonis/Core/Validator'
+
+import { rules } from '../../src/Rules'
+import { schema } from '../../src/Schema'
+import { validate } from '../fixtures/rules/index'
+import { MessagesBag } from '../../src/MessagesBag'
+import { ApiErrorReporter } from '../../src/ErrorReporter'
+import { beforeOrEqual } from '../../src/Validations'
+
+function compile(keyword: 'today' | 'yesterday'): ParsedRule<any>
+// eslint-disable-next-line no-redeclare
+function compile(date: SchemaRef<DateTime>): ParsedRule<any>
+// eslint-disable-next-line no-redeclare
+function compile(interval: number, duration: DurationUnits): ParsedRule<any>
+// eslint-disable-next-line no-redeclare
+function compile(
+  interval: number | SchemaRef<DateTime> | 'today' | 'yesterday',
+  duration?: DurationUnits
+): ParsedRule<any> {
+  const { options } =
+    typeof interval === 'number'
+      ? rules.beforeOrEqual(interval, duration!)
+      : typeof interval === 'string'
+      ? rules.beforeOrEqual(interval)
+      : rules.beforeOrEqual(interval)
+
+  return beforeOrEqual.compile('literal', 'date', options, {})
+}
+
+test.group('Date | Before Or Equal ', () => {
+  validate(
+    beforeOrEqual,
+    test,
+    DateTime.local(),
+    DateTime.local().minus({ days: 2 }),
+    compile(1, 'day')
+  )
+
+  test('do not compile when one argument is passed and is not a ref', (assert) => {
+    const fn = () => beforeOrEqual.compile('literal', 'date', ['foo'])
+    assert.throw(fn, '"beforeOrEqual": expects a date offset "duration" and "unit" or a "ref"')
+  })
+
+  test('do not compile when interval is not a number', (assert) => {
+    const fn = () => beforeOrEqual.compile('literal', 'date', ['foo', 'days'])
+    assert.throw(fn, '"beforeOrEqual": expects "duration" to be a number')
+  })
+
+  test('do not compile when interval no arguments are defined', (assert) => {
+    const fn = () => beforeOrEqual.compile('literal', 'date', [])
+    assert.throw(fn, '"beforeOrEqual": expects a date offset "duration" and "unit" or a "ref"')
+  })
+})
+
+test.group('Date | Before Or Equal | Day', () => {
+  test('report error when date is not before or equal to defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().toISODate()
+
+    beforeOrEqual.validate(DateTime.fromISO(publishedOn!), compile(1, 'day').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'beforeOrEqual')
+    assert.equal(errors.errors[0].message, 'beforeOrEqual date validation failed')
+  })
+
+  /**
+   * The time should have no relevance in case of `days` offset
+   */
+  test('report error when datetime is not before or equal to defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().toISO()
+
+    beforeOrEqual.validate(DateTime.fromISO(publishedOn!), compile(1, 'day').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'beforeOrEqual')
+    assert.equal(errors.errors[0].message, 'beforeOrEqual date validation failed')
+  })
+
+  test('work fine when date is before or equal to defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().minus({ days: 2 }).toISO()
+    const publishedOnSameDate = DateTime.local().minus({ days: 1 }).toISO()
+
+    beforeOrEqual.validate(DateTime.fromISO(publishedOn!), compile(1, 'day').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedOnSameDate!),
+      compile(1, 'day').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_on',
+        pointer: 'published_on',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('report error when date is not before or equal to today', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().plus({ days: 1 }).toISODate()
+
+    beforeOrEqual.validate(DateTime.fromISO(publishedOn!), compile('today').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'beforeOrEqual')
+    assert.equal(errors.errors[0].message, 'beforeOrEqual date validation failed')
+  })
+
+  test('work fine when date is before or equal to today', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().minus({ days: 1 }).toISODate()
+    const publishedOnSameDate = DateTime.local().toISODate()
+
+    beforeOrEqual.validate(DateTime.fromISO(publishedOn!), compile('today').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedOnSameDate!),
+      compile('today').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_on',
+        pointer: 'published_on',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('report error when date is not yesterday today', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().plus({ days: 1 }).toISODate()
+
+    beforeOrEqual.validate(DateTime.fromISO(publishedOn!), compile('yesterday').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_on')
+    assert.equal(errors.errors[0].rule, 'beforeOrEqual')
+    assert.equal(errors.errors[0].message, 'beforeOrEqual date validation failed')
+  })
+
+  test('work fine when date is before or equal to yesterday', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedOn = DateTime.local().minus({ days: 2 }).toISODate()
+    const publishedOnSameDate = DateTime.local().minus({ days: 1 }).toISODate()
+
+    beforeOrEqual.validate(DateTime.fromISO(publishedOn!), compile('yesterday').compiledOptions!, {
+      errorReporter: reporter,
+      field: 'published_on',
+      pointer: 'published_on',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedOnSameDate!),
+      compile('yesterday').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_on',
+        pointer: 'published_on',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+})
+
+test.group('Date | Before Or Equal | Minutes', () => {
+  test('work fine when time is not defined for the same day', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISODate()
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(30, 'minutes').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_at',
+        pointer: 'published_at',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('report error when time is not before or equal to the defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISO()
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(30, 'minutes').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_at',
+        pointer: 'published_at',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'beforeOrEqual')
+    assert.equal(errors.errors[0].message, 'beforeOrEqual date validation failed')
+  })
+
+  test('work fine when time is before or equal to the defined interval', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().minus({ minutes: 40 }).toISO()
+    const publishedAtSameTime = DateTime.local().minus({ minutes: 30 }).toISO()
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(30, 'minutes').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_at',
+        pointer: 'published_at',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAtSameTime!),
+      compile(30, 'minutes').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_at',
+        pointer: 'published_at',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('work fine when time is not defined for yesterday', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().minus({ days: 1 }).toISODate()
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(30, 'minutes').compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'published_at',
+        pointer: 'published_at',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+})
+
+test.group('Date | Before Or Equal | Ref', () => {
+  test('report error when date is not before or equal to the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISODate()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        beforeDate: DateTime.local().minus({ days: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'beforeOrEqual')
+    assert.equal(errors.errors[0].message, 'beforeOrEqual date validation failed')
+  })
+
+  test('report error when datetime is not before or equal to the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().toISO()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        beforeDate: DateTime.local().minus({ minutes: 30 }),
+      }),
+      mutate: () => {},
+    }
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 1)
+    assert.equal(errors.errors[0].field, 'published_at')
+    assert.equal(errors.errors[0].rule, 'beforeOrEqual')
+    assert.equal(errors.errors[0].message, 'beforeOrEqual date validation failed')
+  })
+
+  test('work fine when time is not defined for the same day', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().minus({ minutes: 5 }).toISODate()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        beforeDate: DateTime.local().minus({ minutes: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('work fine when date is before or equal to the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().minus({ days: 11 }).toISODate()
+    const publishedAtSameDate = DateTime.local().minus({ days: 10 }).toISODate()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        beforeDate: DateTime.local().minus({ days: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAtSameDate!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('work fine when datetime is before or equal to the defined ref', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().minus({ minutes: 30 }).toISO()
+    const publishedAtSameDateTime = DateTime.local().minus({ minutes: 10 }).toISO()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        beforeDate: DateTime.local().minus({ minutes: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAtSameDateTime!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+
+  test('work fine when time is not defined for the previous day', (assert) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    const publishedAt = DateTime.local().minus({ days: 1 }).toISODate()
+
+    const validator = {
+      errorReporter: reporter,
+      field: 'published_at',
+      pointer: 'published_at',
+      tip: {},
+      root: {},
+      refs: schema.refs({
+        beforeDate: DateTime.local().minus({ minutes: 10 }),
+      }),
+      mutate: () => {},
+    }
+
+    beforeOrEqual.validate(
+      DateTime.fromISO(publishedAt!),
+      compile(validator.refs.beforeDate).compiledOptions!,
+      validator
+    )
+
+    const errors = reporter.toJSON()
+    assert.lengthOf(errors.errors, 0)
+  })
+})


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Added beforeOrEqual & afterOrEqual validators to handle scenario where a given date from the request body need to be  after/before or equal to today to be valid. [Discussion thread](https://github.com/adonisjs/core/discussions/3451#discussion-3770760)

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if appropriate)

## Further comments

I took the test cases from `after.spec.ts` and `before.spec.ts` and added new logic to test cases to check beforeOrEqual/afterOrEqual validators.
