### PR TITLE
add lowerCase and upperCase mutate options to string

### DIFF
--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -191,6 +191,7 @@ declare module '@ioc:Adonis/Core/Validator' {
    */
   export interface ErrorReporterContract<Messages extends any = any> {
     hasErrors: boolean
+
     report(
       pointer: string,
       rule: string,
@@ -198,7 +199,9 @@ declare module '@ioc:Adonis/Core/Validator' {
       arrayExpressionPointer?: string,
       args?: any
     ): void
+
     toError(): any
+
     toJSON(): Messages
   }
 
@@ -286,26 +289,104 @@ declare module '@ioc:Adonis/Core/Validator' {
    * Signature to define a string or optional string type
    */
   export interface StringType {
-    (options?: { escape?: boolean; trim?: boolean } | Rule[], rules?: Rule[]): {
+    (
+      options?:
+        | ({
+            escape?: boolean
+            trim?: boolean
+          } & (
+            | {
+                lowerCase?: true
+                upperCase?: false
+              }
+            | {
+                lowerCase?: false
+                upperCase?: true
+              }
+            | {
+                lowerCase?: false
+                upperCase?: false
+              }
+          ))
+        | Rule[],
+      rules?: Rule[]
+    ): {
       t: string
       getTree(): SchemaLiteral
     }
+
     optional(
-      options?: { escape?: boolean; trim?: boolean } | Rule[],
+      options?:
+        | ({
+            escape?: boolean
+            trim?: boolean
+          } & (
+            | {
+                lowerCase?: true
+                upperCase?: false
+              }
+            | {
+                lowerCase?: false
+                upperCase?: true
+              }
+            | {
+                lowerCase?: false
+                upperCase?: false
+              }
+          ))
+        | Rule[],
       rules?: Rule[]
     ): {
       t?: string
       getTree(): SchemaLiteral
     }
+
     nullable(
-      options?: { escape?: boolean; trim?: boolean } | Rule[],
+      options?:
+        | ({
+            escape?: boolean
+            trim?: boolean
+          } & (
+            | {
+                lowerCase?: true
+                upperCase?: false
+              }
+            | {
+                lowerCase?: false
+                upperCase?: true
+              }
+            | {
+                lowerCase?: false
+                upperCase?: false
+              }
+          ))
+        | Rule[],
       rules?: Rule[]
     ): {
       t: string | null
       getTree(): SchemaLiteral
     }
+
     nullableAndOptional(
-      options?: { escape?: boolean; trim?: boolean } | Rule[],
+      options?:
+        | ({
+            escape?: boolean
+            trim?: boolean
+          } & (
+            | {
+                lowerCase?: true
+                upperCase?: false
+              }
+            | {
+                lowerCase?: false
+                upperCase?: true
+              }
+            | {
+                lowerCase?: false
+                upperCase?: false
+              }
+          ))
+        | Rule[],
       rules?: Rule[]
     ): {
       t?: string | null
@@ -321,6 +402,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: DateTime
       getTree(): SchemaLiteral
     }
+
     optional(
       options?: { format?: string },
       rules?: Rule[]
@@ -328,6 +410,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t?: DateTime
       getTree(): SchemaLiteral
     }
+
     nullable(
       options?: { format?: string },
       rules?: Rule[]
@@ -335,6 +418,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: DateTime | null
       getTree(): SchemaLiteral
     }
+
     nullableAndOptional(
       options?: { format?: string },
       rules?: Rule[]
@@ -352,14 +436,17 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: boolean
       getTree(): SchemaLiteral
     }
+
     optional(rules?: Rule[]): {
       t?: boolean
       getTree(): SchemaLiteral
     }
+
     nullable(rules?: Rule[]): {
       t: boolean | null
       getTree(): SchemaLiteral
     }
+
     nullableAndOptional(rules?: Rule[]): {
       t?: boolean | null
       getTree(): SchemaLiteral
@@ -374,14 +461,17 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: number
       getTree(): SchemaLiteral
     }
+
     optional(rules?: Rule[]): {
       t?: number
       getTree(): SchemaLiteral
     }
+
     nullable(rules?: Rule[]): {
       t: number | null
       getTree(): SchemaLiteral
     }
+
     nullableAndOptional(rules?: Rule[]): {
       t?: number | null
       getTree(): SchemaLiteral
@@ -405,6 +495,7 @@ declare module '@ioc:Adonis/Core/Validator' {
         getTree(): SchemaObject
       }
     }
+
     optional(rules?: Rule[]): {
       members<T extends TypedSchema>(
         schema: T
@@ -417,6 +508,7 @@ declare module '@ioc:Adonis/Core/Validator' {
         getTree(): SchemaObject
       }
     }
+
     nullable(rules?: Rule[]): {
       members<T extends TypedSchema>(
         schema: T
@@ -429,6 +521,7 @@ declare module '@ioc:Adonis/Core/Validator' {
         getTree(): SchemaObject
       }
     }
+
     nullableAndOptional(rules?: Rule[]): {
       members<T extends TypedSchema>(
         schema: T
@@ -460,6 +553,7 @@ declare module '@ioc:Adonis/Core/Validator' {
         getTree(): SchemaArray
       }
     }
+
     optional(rules?: Rule[]): {
       members<T extends { t?: any; getTree(): SchemaLiteral | SchemaObject | SchemaArray }>(
         schema: T
@@ -472,6 +566,7 @@ declare module '@ioc:Adonis/Core/Validator' {
         getTree(): SchemaArray
       }
     }
+
     nullable(rules?: Rule[]): {
       members<T extends { t?: any; getTree(): SchemaLiteral | SchemaObject | SchemaArray }>(
         schema: T
@@ -484,6 +579,7 @@ declare module '@ioc:Adonis/Core/Validator' {
         getTree(): SchemaArray
       }
     }
+
     nullableAndOptional(rules?: Rule[]): {
       members<T extends { t?: any; getTree(): SchemaLiteral | SchemaObject | SchemaArray }>(
         schema: T
@@ -538,6 +634,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: EnumReturnValue<Options>
       getTree(): SchemaLiteral
     }
+
     optional<Options extends AllowedEnumOptions>(
       options: Options,
       rules?: Rule[]
@@ -545,6 +642,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t?: EnumReturnValue<Options>
       getTree(): SchemaLiteral
     }
+
     nullable<Options extends AllowedEnumOptions>(
       options: Options,
       rules?: Rule[]
@@ -552,6 +650,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: EnumReturnValue<Options> | null
       getTree(): SchemaLiteral
     }
+
     nullableAndOptional<Options extends AllowedEnumOptions>(
       options: Options,
       rules?: Rule[]
@@ -569,6 +668,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: EnumSetReturnValue<Options>
       getTree(): SchemaLiteral
     }
+
     optional<Options extends AllowedEnumOptions>(
       options: Options,
       rules?: Rule[]
@@ -576,6 +676,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t?: EnumSetReturnValue<Options>
       getTree(): SchemaLiteral
     }
+
     nullable<Options extends AllowedEnumOptions>(
       options: Options,
       rules?: Rule[]
@@ -583,6 +684,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: EnumSetReturnValue<Options> | null
       getTree(): SchemaLiteral
     }
+
     nullableAndOptional<Options extends AllowedEnumOptions>(
       options: Options,
       rules?: Rule[]
@@ -600,6 +702,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: MultipartFileContract
       getTree(): SchemaLiteral
     }
+
     optional(
       options?: Partial<FileValidationOptions>,
       rules?: Rule[]
@@ -607,6 +710,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t?: MultipartFileContract
       getTree(): SchemaLiteral
     }
+
     nullable(
       options?: Partial<FileValidationOptions>,
       rules?: Rule[]
@@ -614,6 +718,7 @@ declare module '@ioc:Adonis/Core/Validator' {
       t: MultipartFileContract | null
       getTree(): SchemaLiteral
     }
+
     nullableAndOptional(
       options?: Partial<FileValidationOptions>,
       rules?: Rule[]
@@ -647,6 +752,7 @@ declare module '@ioc:Adonis/Core/Validator' {
     array: ArrayType
     file: FileType
     refs: <T extends Object>(refs: T) => { [K in keyof T]: SchemaRef<T[K]> }
+
     create<T extends TypedSchema>(schema: T): ParsedTypedSchema<T>
   }
 
@@ -855,11 +961,13 @@ declare module '@ioc:Adonis/Core/Validator' {
       operator: 'in' | 'notIn',
       comparisonValues: any[] | SchemaRef<any[]>
     ): Rule
+
     requiredWhen(
       field: string,
       operator: '>' | '<' | '>=' | '<=',
       comparisonValue: number | SchemaRef<number>
     ): Rule
+
     requiredWhen(
       field: string,
       operator: 'in' | 'notIn' | '=' | '!=' | '>' | '<' | '>=' | '<=',

--- a/src/Schema/index.ts
+++ b/src/Schema/index.ts
@@ -29,15 +29,55 @@ import {
 /**
  * String schema type
  */
-function string(options?: { escape?: boolean; trim?: boolean } | Rule[], rules?: Rule[]) {
+function string(
+  options?:
+    | ({
+        escape?: boolean
+        trim?: boolean
+      } & (
+        | {
+            lowerCase?: true
+            upperCase?: false
+          }
+        | {
+            lowerCase?: false
+            upperCase?: true
+          }
+        | {
+            lowerCase?: false
+            upperCase?: false
+          }
+      ))
+    | Rule[],
+  rules?: Rule[]
+) {
   if (!rules && Array.isArray(options)) {
     rules = options
     options = {}
   }
   return getLiteralType('string', false, false, options, rules || []) as ReturnType<StringType>
 }
+
 string.optional = function optionalString(
-  options?: { escape?: boolean; trim?: boolean } | Rule[],
+  options?:
+    | ({
+        escape?: boolean
+        trim?: boolean
+      } & (
+        | {
+            lowerCase?: true
+            upperCase?: false
+          }
+        | {
+            lowerCase?: false
+            upperCase?: true
+          }
+        | {
+            lowerCase?: false
+            upperCase?: false
+          }
+      ))
+    | Rule[],
   rules?: Rule[]
 ) {
   if (!rules && Array.isArray(options)) {
@@ -49,7 +89,25 @@ string.optional = function optionalString(
   >
 }
 string.nullable = function nullableString(
-  options?: { escape?: boolean; trim?: boolean } | Rule[],
+  options?:
+    | ({
+        escape?: boolean
+        trim?: boolean
+      } & (
+        | {
+            lowerCase?: true
+            upperCase?: false
+          }
+        | {
+            lowerCase?: false
+            upperCase?: true
+          }
+        | {
+            lowerCase?: false
+            upperCase?: false
+          }
+      ))
+    | Rule[],
   rules?: Rule[]
 ) {
   if (!rules && Array.isArray(options)) {
@@ -61,7 +119,25 @@ string.nullable = function nullableString(
   >
 }
 string.nullableAndOptional = function nullableAndOptionalString(
-  options?: { escape?: boolean; trim?: boolean } | Rule[],
+  options?:
+    | ({
+        escape?: boolean
+        trim?: boolean
+      } & (
+        | {
+            lowerCase?: true
+            upperCase?: false
+          }
+        | {
+            lowerCase?: false
+            upperCase?: true
+          }
+        | {
+            lowerCase?: false
+            upperCase?: false
+          }
+      ))
+    | Rule[],
   rules?: Rule[]
 ) {
   if (!rules && Array.isArray(options)) {
@@ -79,6 +155,7 @@ string.nullableAndOptional = function nullableAndOptionalString(
 function boolean(rules?: Rule[]) {
   return getLiteralType('boolean', false, false, undefined, rules || []) as ReturnType<BooleanType>
 }
+
 boolean.optional = function optionalBoolean(rules?: Rule[]) {
   return getLiteralType('boolean', true, false, undefined, rules || []) as ReturnType<
     BooleanType['optional']
@@ -101,6 +178,7 @@ boolean.nullableAndOptional = function nullableAndOptionalBoolean(rules?: Rule[]
 function number(rules?: Rule[]) {
   return getLiteralType('number', false, false, undefined, rules || []) as ReturnType<NumberType>
 }
+
 number.optional = function optionalNumber(rules?: Rule[]) {
   return getLiteralType('number', true, false, undefined, rules || []) as ReturnType<
     NumberType['optional']
@@ -123,6 +201,7 @@ number.nullableAndOptional = function nullableAndOptionalNumber(rules?: Rule[]) 
 function date(options?: { format: string }, rules?: Rule[]) {
   return getLiteralType('date', false, false, options, rules || []) as ReturnType<DateType>
 }
+
 date.optional = function optionalDate(options?: { format: string }, rules?: Rule[]) {
   return getLiteralType('date', true, false, options, rules || []) as ReturnType<
     DateType['optional']
@@ -163,6 +242,7 @@ function object(rules?: Rule[]) {
     },
   } as ReturnType<ObjectType>
 }
+
 object.optional = function optionalObject(rules?: Rule[]) {
   return {
     members(schema: any) {
@@ -231,6 +311,7 @@ function array(rules?: Rule[]) {
     },
   } as ReturnType<ArrayType>
 }
+
 array.optional = function optionalArray(rules?: Rule[]) {
   return {
     members(schema: any) {
@@ -268,6 +349,7 @@ array.nullableAndOptional = function nullableAndOptionalArray(rules?: Rule[]) {
 function oneOf(enumOptions: any[], rules?: Rule[]) {
   return getLiteralType('enum', false, false, enumOptions, rules || []) as ReturnType<EnumType>
 }
+
 oneOf.optional = function optionalEnum(enumOptions: any[], rules?: Rule[]) {
   return getLiteralType('enum', true, false, enumOptions, rules || []) as ReturnType<
     EnumType['optional']
@@ -296,6 +378,7 @@ function enumSet(enumOptions: any[], rules?: Rule[]) {
     rules || []
   ) as ReturnType<EnumSetType>
 }
+
 enumSet.optional = function optionalEnumSet(enumOptions: any[], rules?: Rule[]) {
   return getLiteralType('enumSet', true, false, enumOptions, rules || []) as ReturnType<
     EnumSetType['optional']
@@ -321,6 +404,7 @@ enumSet.nullableAndOptional = function nullableAndOptionalEnumSet(
 function file(options: any, rules?: Rule[]) {
   return getLiteralType('file', false, false, options, rules || []) as ReturnType<FileType>
 }
+
 file.optional = function optionalFile(options: any, rules?: Rule[]) {
   return getLiteralType('file', true, false, options, rules || []) as ReturnType<
     FileType['optional']

--- a/src/Validations/primitives/string.ts
+++ b/src/Validations/primitives/string.ts
@@ -18,12 +18,19 @@ const RULE_NAME = 'string'
  * Ensure value is a valid string
  * @type {SyncValidation}
  */
-export const string: SyncValidation<{ escape: boolean; trim: boolean }> = {
+export const string: SyncValidation<{
+  escape: boolean
+  trim: boolean
+  upperCase: boolean
+  lowerCase: boolean
+}> = {
   compile: wrapCompile(RULE_NAME, [], ([options]) => {
     return {
       compiledOptions: {
         escape: !!(options && options.escape),
         trim: !!(options && options.trim),
+        upperCase: !!(options && options.upperCase),
+        lowerCase: !!(options && options.lowerCase),
       },
     }
   }),
@@ -49,6 +56,22 @@ export const string: SyncValidation<{ escape: boolean; trim: boolean }> = {
     if (compiledOptions.trim) {
       mutated = true
       value = value.trim()
+    }
+
+    /**
+     * UpperCase string
+     */
+    if (compiledOptions.upperCase) {
+      mutated = true
+      value = value.toLocaleUpperCase()
+    }
+
+    /**
+     * LowerCase string
+     */
+    if (compiledOptions.lowerCase) {
+      mutated = true
+      value = value.toLocaleLowerCase()
     }
 
     mutated && mutate(value)

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -34,7 +34,7 @@ test.group('Schema | String', () => {
               name: 'string',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { escape: false, trim: false },
+              compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: false },
             },
           ],
         },
@@ -58,7 +58,7 @@ test.group('Schema | String', () => {
               name: 'string',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { escape: false, trim: false },
+              compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: false },
             },
           ],
         },
@@ -88,7 +88,7 @@ test.group('Schema | String', () => {
               name: 'string',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { escape: false, trim: false },
+              compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: false },
             },
           ],
         },
@@ -112,7 +112,7 @@ test.group('Schema | String', () => {
               name: 'string',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { escape: false, trim: false },
+              compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: false },
             },
           ],
         },
@@ -142,7 +142,7 @@ test.group('Schema | String', () => {
               name: 'string',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { escape: false, trim: false },
+              compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: false },
             },
             {
               name: 'alpha',
@@ -180,7 +180,7 @@ test.group('Schema | String', () => {
               name: 'string',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { escape: true, trim: false },
+              compiledOptions: { escape: true, trim: false, upperCase: false, lowerCase: false },
             },
           ],
         },
@@ -210,7 +210,67 @@ test.group('Schema | String', () => {
               name: 'string',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { escape: true, trim: true },
+              compiledOptions: { escape: true, trim: true, upperCase: false, lowerCase: false },
+            },
+          ],
+        },
+      }
+    )
+  })
+
+  test('turn on upperCase', ({ assert }) => {
+    assert.deepEqual(
+      schema.create({
+        username: schema.string({ escape: false, trim: false, upperCase: true, lowerCase: false }),
+      }).tree,
+      {
+        username: {
+          type: 'literal',
+          subtype: 'string',
+          optional: false,
+          nullable: false,
+          rules: [
+            {
+              name: 'required',
+              allowUndefineds: true,
+              async: false,
+              compiledOptions: [],
+            },
+            {
+              name: 'string',
+              allowUndefineds: false,
+              async: false,
+              compiledOptions: { escape: false, trim: false, upperCase: true, lowerCase: false },
+            },
+          ],
+        },
+      }
+    )
+  })
+
+  test('turn on lowerCase', ({ assert }) => {
+    assert.deepEqual(
+      schema.create({
+        username: schema.string({ escape: false, trim: false, upperCase: false, lowerCase: true }),
+      }).tree,
+      {
+        username: {
+          type: 'literal',
+          subtype: 'string',
+          optional: false,
+          nullable: false,
+          rules: [
+            {
+              name: 'required',
+              allowUndefineds: true,
+              async: false,
+              compiledOptions: [],
+            },
+            {
+              name: 'string',
+              allowUndefineds: false,
+              async: false,
+              compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: true },
             },
           ],
         },
@@ -911,7 +971,12 @@ test.group('Schema | Object', () => {
                   name: 'string',
                   allowUndefineds: false,
                   async: false,
-                  compiledOptions: { escape: false, trim: false },
+                  compiledOptions: {
+                    escape: false,
+                    trim: false,
+                    upperCase: false,
+                    lowerCase: false,
+                  },
                 },
               ],
             },
@@ -958,7 +1023,12 @@ test.group('Schema | Object', () => {
                   name: 'string',
                   allowUndefineds: false,
                   async: false,
-                  compiledOptions: { escape: false, trim: false },
+                  compiledOptions: {
+                    escape: false,
+                    trim: false,
+                    upperCase: false,
+                    lowerCase: false,
+                  },
                 },
               ],
             },
@@ -1011,7 +1081,12 @@ test.group('Schema | Object', () => {
                   name: 'string',
                   allowUndefineds: false,
                   async: false,
-                  compiledOptions: { escape: false, trim: false },
+                  compiledOptions: {
+                    escape: false,
+                    trim: false,
+                    upperCase: false,
+                    lowerCase: false,
+                  },
                 },
               ],
             },
@@ -1058,7 +1133,12 @@ test.group('Schema | Object', () => {
                   name: 'string',
                   allowUndefineds: false,
                   async: false,
-                  compiledOptions: { escape: false, trim: false },
+                  compiledOptions: {
+                    escape: false,
+                    trim: false,
+                    upperCase: false,
+                    lowerCase: false,
+                  },
                 },
               ],
             },
@@ -1162,7 +1242,12 @@ test.group('Schema | Array', () => {
                     name: 'string',
                     allowUndefineds: false,
                     async: false,
-                    compiledOptions: { escape: false, trim: false },
+                    compiledOptions: {
+                      escape: false,
+                      trim: false,
+                      upperCase: false,
+                      lowerCase: false,
+                    },
                   },
                 ],
               },
@@ -1230,7 +1315,12 @@ test.group('Schema | Array', () => {
                     name: 'string',
                     allowUndefineds: false,
                     async: false,
-                    compiledOptions: { escape: false, trim: false },
+                    compiledOptions: {
+                      escape: false,
+                      trim: false,
+                      upperCase: false,
+                      lowerCase: false,
+                    },
                   },
                 ],
               },
@@ -1304,7 +1394,12 @@ test.group('Schema | Array', () => {
                     name: 'string',
                     allowUndefineds: false,
                     async: false,
-                    compiledOptions: { escape: false, trim: false },
+                    compiledOptions: {
+                      escape: false,
+                      trim: false,
+                      upperCase: false,
+                      lowerCase: false,
+                    },
                   },
                 ],
               },
@@ -1384,7 +1479,12 @@ test.group('Schema | Array', () => {
                     name: 'string',
                     allowUndefineds: false,
                     async: false,
-                    compiledOptions: { escape: false, trim: false },
+                    compiledOptions: {
+                      escape: false,
+                      trim: false,
+                      upperCase: false,
+                      lowerCase: false,
+                    },
                   },
                 ],
               },
@@ -1487,7 +1587,7 @@ test.group('Schema | Array', () => {
                 name: 'string',
                 allowUndefineds: false,
                 async: false,
-                compiledOptions: { escape: false, trim: false },
+                compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: false },
               },
             ],
           },
@@ -1530,7 +1630,7 @@ test.group('Schema | Array', () => {
                 name: 'string',
                 allowUndefineds: false,
                 async: false,
-                compiledOptions: { escape: false, trim: false },
+                compiledOptions: { escape: false, trim: false, upperCase: false, lowerCase: false },
               },
             ],
           },

--- a/test/validations/string.spec.ts
+++ b/test/validations/string.spec.ts
@@ -14,7 +14,21 @@ import { MessagesBag } from '../../src/MessagesBag'
 import { ApiErrorReporter } from '../../src/ErrorReporter'
 import { string } from '../../src/Validations/primitives/string'
 
-function compile(options?: { escape: true }) {
+function compile(
+  options?: {
+    escape?: boolean
+    trim?: boolean
+  } & (
+    | {
+        lowerCase?: true
+        upperCase?: false
+      }
+    | {
+        lowerCase?: false
+        upperCase?: true
+      }
+  )
+) {
   return string.compile('literal', 'string', rules['string'](options).options, {})
 }
 
@@ -97,5 +111,39 @@ test.group('String', () => {
     })
 
     assert.equal(value, '&lt;p&gt;hello world&lt;&#x2F;p&gt;')
+  })
+
+  test('upperCase string when enabled', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    let value = 'tRacK_CoDe-34@i'
+
+    string.validate(value, compile({ upperCase: true }).compiledOptions, {
+      errorReporter: reporter,
+      field: 'username',
+      pointer: 'username',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: (newValue) => (value = newValue),
+    })
+
+    assert.equal(value, 'TRACK_CODE-34@I')
+  })
+
+  test('lowerCase string when enabled', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    let value = 'MyEmail@example.com'
+
+    string.validate(value, compile({ lowerCase: true }).compiledOptions, {
+      errorReporter: reporter,
+      field: 'username',
+      pointer: 'username',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: (newValue) => (value = newValue),
+    })
+
+    assert.equal(value, 'myemail@example.com')
   })
 })


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Added lowerCase and upperCase mutate options to string validation.

**Why?**

For example, the email address is not case-sensitive. Also, the e-mail address is a unique value. I know `rules.email()` has already [lowerCase sanitization](https://github.com/adonisjs/validator/blob/b00a2cfe6408fbfe9d99cd17b4f79cb63363a2eb/src/Validations/string/email.ts#L110) but that's only an example. Username can be given as an example instead of email address.

`email: schema.string({ trim: true }, [
      rules.email(),
      rules.unique({ table: 'users', column: 'email' })
    ])`

The unique validation above will be unnecessary for these 2 values:
```
example@example.com
Example@example.com
```

We can validate this just by add the lowercase property to string options:

`email: schema.string({ trim: true, lowerCase: true }, [
      rules.email(),
      rules.unique({ table: 'users', column: 'email' })
    ])`

Unique control is now really functional.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I made a type check to don't use both lowerCase and upperCase at the same time but type controls are constantly duplicated in the project. (In validator.ts, schema/index.ts and etc.) I think this can be improved.
