### PR TITLE
chore(deps): bump third validator from 13.7.0 to 13.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,11 +109,11 @@
 	"dependencies": {
 		"@poppinss/utils": "^5.0.0",
 		"@types/luxon": "^3.0.1",
-		"@types/validator": "^13.7.10",
+		"@types/validator": "^13.7.17",
 		"luxon": "^3.0.3",
 		"normalize-url": "^6.1.0",
 		"tmp-cache": "^1.1.0",
-		"validator": "^13.7.0"
+		"validator": "^13.9.0"
 	},
 	"peerDependencies": {
 		"@adonisjs/application": "^5.0.0",


### PR DESCRIPTION
## Proposed changes

The [latest version of the package](https://github.com/validatorjs/validator.js/releases/tag/13.9.0) fixes many issues.
I needed to create a custom rule to use the latest version, because the oldest version have an issue that doesn't works with mobile brazilian numbers.

## Types of changes

What types of changes does your code introduce?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
