### PR TITLE
Ensure fail validation for number casted to Infinity

### DIFF
--- a/src/Validations/primitives/number.ts
+++ b/src/Validations/primitives/number.ts
@@ -42,6 +42,11 @@ export const number: SyncValidation = {
       return
     }
 
+    if (castedValue === Infinity || castedValue === -Infinity) {
+      errorReporter.report(pointer, RULE_NAME, DEFAULT_MESSAGE, arrayExpressionPointer)
+      return
+    }
+
     /**
      * Mutate the value
      */

--- a/test/validations/number.spec.ts
+++ b/test/validations/number.spec.ts
@@ -21,6 +21,33 @@ function compile() {
 test.group('Number', () => {
   validate(number, test, 'helloworld', 10, compile())
 
+  test('report error when value is near Infinity', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    number.validate(
+      '-3177777777777777777777777777777777777777777777777777777777777777777777777770000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000009999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999991111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111',
+      compile().compiledOptions,
+      {
+        errorReporter: reporter,
+        field: 'age',
+        pointer: 'age',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    assert.deepEqual(reporter.toJSON(), {
+      errors: [
+        {
+          field: 'age',
+          rule: 'number',
+          message: 'number validation failed',
+        },
+      ],
+    })
+  })
+
   test('report error when value is not a valid number', ({ assert }) => {
     const reporter = new ApiErrorReporter(new MessagesBag({}), false)
     number.validate(null, compile().compiledOptions, {


### PR DESCRIPTION
Hey there! 👋🏻 

This PR ensures to fail the validation when sending a long string number that will be casted to `Infinity` or `-Infinity`.