### PR TITLE
include luxon date time options to date

### DIFF
--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -10,7 +10,7 @@
 declare module '@ioc:Adonis/Core/Validator' {
   import { UUIDVersion } from 'validator/lib/isUUID'
   import { default as validatorJs } from 'validator'
-  import { DateTime, DurationObjectUnits } from 'luxon'
+  import { DateTime, DateTimeOptions, DurationObjectUnits } from 'luxon'
   import { RequestContract } from '@ioc:Adonis/Core/Request'
   import { Options as NormalizeUrlOptions } from 'normalize-url'
   import { HttpContextContract } from '@ioc:Adonis/Core/HttpContext'
@@ -317,26 +317,26 @@ declare module '@ioc:Adonis/Core/Validator' {
    * Signature to define a date or an optional date type
    */
   export interface DateType {
-    (options?: { format?: string }, rules?: Rule[]): {
+    (options?: { format?: string; opts?: DateTimeOptions }, rules?: Rule[]): {
       t: DateTime
       getTree(): SchemaLiteral
     }
     optional(
-      options?: { format?: string },
+      options?: { format?: string; opts?: DateTimeOptions },
       rules?: Rule[]
     ): {
       t?: DateTime
       getTree(): SchemaLiteral
     }
     nullable(
-      options?: { format?: string },
+      options?: { format?: string; opts?: DateTimeOptions },
       rules?: Rule[]
     ): {
       t: DateTime | null
       getTree(): SchemaLiteral
     }
     nullableAndOptional(
-      options?: { format?: string },
+      options?: { format?: string; opts?: DateTimeOptions },
       rules?: Rule[]
     ): {
       t?: DateTime | null

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@adonisjs/validator",
-	"version": "12.5.0",
+	"version": "12.6.0",
 	"description": "Validator for adonis framework",
 	"main": "build/providers/ValidatorProvider.js",
 	"files": [

--- a/src/Validations/date/helpers/field.ts
+++ b/src/Validations/date/helpers/field.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { DateTime } from 'luxon'
+import { DateTime, DateTimeOptions } from 'luxon'
 import { ValidationRuntimeOptions } from '@ioc:Adonis/Core/Validator'
 
 import { toLuxon } from './toLuxon'
@@ -20,6 +20,7 @@ export type CompileReturnType = {
   operator: '>' | '<' | '>=' | '<='
   field: string
   format?: string
+  opts?: DateTimeOptions
 }
 
 /**
@@ -60,6 +61,7 @@ export function compile(
       operator,
       field,
       format: rulesTree.date?.format,
+      opts: rulesTree.date?.opts,
     },
   }
 }
@@ -71,7 +73,7 @@ export function validate(
   ruleName: string,
   errorMessage: string,
   value: any,
-  { field, operator, format }: CompileReturnType,
+  { field, operator, format, opts }: CompileReturnType,
   { root, tip, errorReporter, pointer, arrayExpressionPointer }: ValidationRuntimeOptions
 ) {
   /**
@@ -82,7 +84,7 @@ export function validate(
     return
   }
 
-  const comparisonValue = toLuxon(getFieldValue(field, root, tip), format)
+  const comparisonValue = toLuxon(getFieldValue(field, root, tip), format, opts)
 
   /**
    * Raise error when comparison field is not a valid date

--- a/src/Validations/date/helpers/toLuxon.ts
+++ b/src/Validations/date/helpers/toLuxon.ts
@@ -7,7 +7,7 @@
  * file that was distributed with this source code.
  */
 
-import { DateTime } from 'luxon'
+import { DateTime, DateTimeOptions } from 'luxon'
 
 /**
  * A list of pre-defined formats and their luxon specific methods
@@ -22,7 +22,11 @@ const PREDEFINED_FORMATS = {
 /**
  * Convers a value to an instance of datetime
  */
-export function toLuxon(value: any, format: string | undefined): DateTime | undefined {
+export function toLuxon(
+  value: any,
+  format: string | undefined,
+  opts: DateTimeOptions | undefined
+): DateTime | undefined {
   let dateTime: DateTime | undefined
 
   /**
@@ -35,7 +39,9 @@ export function toLuxon(value: any, format: string | undefined): DateTime | unde
     dateTime = value
   } else if (typeof value === 'string') {
     const formatterFn = PREDEFINED_FORMATS[format || 'iso']
-    dateTime = formatterFn ? DateTime[formatterFn](value) : DateTime.fromFormat(value, format!)
+    dateTime = formatterFn
+      ? DateTime[formatterFn](value, opts)
+      : DateTime.fromFormat(value, format!, opts)
   }
 
   return dateTime

--- a/src/Validations/primitives/date.ts
+++ b/src/Validations/primitives/date.ts
@@ -11,6 +11,7 @@ import { SyncValidation } from '@ioc:Adonis/Core/Validator'
 
 import { wrapCompile } from '../../Validator/helpers'
 import { toLuxon } from '../date/helpers/toLuxon'
+import { DateTimeOptions } from 'luxon'
 
 const RULE_NAME = 'date'
 const DEFAULT_MESSAGE = 'date validation failed'
@@ -19,15 +20,18 @@ const CANNOT_VALIDATE = 'cannot validate date instance against a date format'
 /**
  * Ensure the value is a valid date instance
  */
-export const date: SyncValidation<{ format?: string }> = {
+export const date: SyncValidation<{ format?: string; opts?: DateTimeOptions }> = {
   compile: wrapCompile(RULE_NAME, [], ([options]) => {
     return {
-      compiledOptions: { format: options && options.format },
+      compiledOptions: {
+        format: options && options.format,
+        opts: options && options.opts,
+      },
     }
   }),
   validate(value, compiledOptions, { mutate, errorReporter, pointer, arrayExpressionPointer }) {
     const isDateInstance = value instanceof Date
-    const dateTime = toLuxon(value, compiledOptions.format)
+    const dateTime = toLuxon(value, compiledOptions.format, compiledOptions.opts)
 
     if (isDateInstance && compiledOptions.format) {
       errorReporter.report(pointer, RULE_NAME, CANNOT_VALIDATE, arrayExpressionPointer, {

--- a/test/schema.spec.ts
+++ b/test/schema.spec.ts
@@ -500,6 +500,7 @@ test.group('Schema | Date', () => {
               async: false,
               compiledOptions: {
                 format: undefined,
+                opts: undefined,
               },
             },
           ],
@@ -526,6 +527,7 @@ test.group('Schema | Date', () => {
               async: false,
               compiledOptions: {
                 format: undefined,
+                opts: undefined,
               },
             },
           ],
@@ -558,6 +560,7 @@ test.group('Schema | Date', () => {
               async: false,
               compiledOptions: {
                 format: undefined,
+                opts: undefined,
               },
             },
           ],
@@ -584,6 +587,7 @@ test.group('Schema | Date', () => {
               async: false,
               compiledOptions: {
                 format: undefined,
+                opts: undefined,
               },
             },
           ],
@@ -592,10 +596,10 @@ test.group('Schema | Date', () => {
     )
   })
 
-  test('define schema with date rule and a format', ({ assert }) => {
+  test('define schema with date rule and options', ({ assert }) => {
     assert.deepEqual(
       schema.create({
-        username: schema.date({ format: 'iso' }),
+        username: schema.date({ format: 'iso', opts: { zone: 'UTC-4' } }),
       }).tree,
       {
         username: {
@@ -614,7 +618,7 @@ test.group('Schema | Date', () => {
               name: 'date',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { format: 'iso' },
+              compiledOptions: { format: 'iso', opts: { zone: 'UTC-4' } },
             },
           ],
         },
@@ -622,10 +626,10 @@ test.group('Schema | Date', () => {
     )
   })
 
-  test('define schema with optional date rule and a format', ({ assert }) => {
+  test('define schema with optional date rule and options', ({ assert }) => {
     assert.deepEqual(
       schema.create({
-        username: schema.date.optional({ format: 'iso' }),
+        username: schema.date.optional({ format: 'iso', opts: { zone: 'UTC-4' } }),
       }).tree,
       {
         username: {
@@ -638,7 +642,7 @@ test.group('Schema | Date', () => {
               name: 'date',
               allowUndefineds: false,
               async: false,
-              compiledOptions: { format: 'iso' },
+              compiledOptions: { format: 'iso', opts: { zone: 'UTC-4' } },
             },
           ],
         },

--- a/test/validations/date.spec.ts
+++ b/test/validations/date.spec.ts
@@ -13,9 +13,9 @@ import { validate } from '../fixtures/rules/index'
 import { MessagesBag } from '../../src/MessagesBag'
 import { ApiErrorReporter } from '../../src/ErrorReporter'
 import { date } from '../../src/Validations/primitives/date'
-import { DateTime } from 'luxon'
+import { DateTime, DateTimeOptions } from 'luxon'
 
-function compile(options: { format?: string }) {
+function compile(options: { format?: string; opts?: DateTimeOptions }) {
   return date.compile('literal', 'date', rules['date'](options).options, {})
 }
 
@@ -131,6 +131,60 @@ test.group('Date', () => {
     })
 
     assert.instanceOf(value, DateTime)
+    assert.deepEqual(reporter.toJSON(), { errors: [] })
+  })
+
+  test('report error when value is valid but a option is invalid', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    date.validate(
+      '2020-12-10',
+      compile({ format: 'iso', opts: { zone: 'INVALID' } }).compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'dob',
+        pointer: 'dob',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: () => {},
+      }
+    )
+
+    assert.deepEqual(reporter.toJSON(), {
+      errors: [
+        {
+          field: 'dob',
+          rule: 'date.format',
+          message: 'the zone "INVALID" is not supported',
+          args: { format: 'iso' },
+        },
+      ],
+    })
+  })
+
+  test('work fine when value is valid as per pre-defined format with opts', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    let value: any = '2023-09-28T21:05:05.903Z'
+
+    date.validate(
+      '2023-09-28T21:05:05.903Z',
+      compile({ format: 'iso', opts: { zone: 'UTC-4' } }).compiledOptions!,
+      {
+        errorReporter: reporter,
+        field: 'dob',
+        pointer: 'dob',
+        tip: {},
+        root: {},
+        refs: {},
+        mutate: (newValue) => {
+          value = newValue
+        },
+      }
+    )
+
+    assert.instanceOf(value, DateTime)
+    assert.deepEqual(value.zoneName, 'UTC-4')
+    assert.deepEqual(value.toString(), '2023-09-28T17:05:05.903-04:00')
     assert.deepEqual(reporter.toJSON(), { errors: [] })
   })
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Including the luxon date time options increases the developer's possibilities in other scenarios, here are some of them:

- It is required to receive a date in ISO format and the validation result must return the time zone specified by the developer (ex: UTC): 
`{
  published_at: schema.date({
    format: 'iso',
    opts: {
      zone: 'UTC'
    }
  })
}`
`input: 2023-09-28T17:05:05.903-04:00`
`output: 2023-09-28T21:05:05.903Z`

- It is required to receive a date in ISO format and the validation result to return a DateTime object with the same input time zone, not necessarily the default time zone as it currently works, (assume default time zone in UTC):

`{
  published_at: schema.date({
    format: 'iso',
    opts: {
      setZone:  true
    }
  })
}`
`input: 2023-09-28T17:05:05.903-04:00`
`expected output equals to input: 2023-09-28T17:05:05.903-04:00`
`current output: 2023-09-28T21:05:05.903Z`

- Reuse a schema in different parts ensuring the same output format, consider a data enrichment scenario where you have a validation scheme that includes a date with ISO format, in step 1 a DateTime object is created with a different time zone to the default, it is validated and everything is ok, the user serializes the response and saves it in some storage as json, then in step 2 he recovers the serialized result, makes some changes and wants to use the same schema to validate, like now the field validated as date is a string, the validator internally creates a new DateTime that will remain with the default time zone, when serializing again to continue the sequence of steps, the stored data will be in a different format than the one initially set

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/.github/CONTRIBUTING.md) doc
- [X] Lint and unit tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
