### PR TITLE
Create min and max validators for number type 

### DIFF
--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -1072,6 +1072,13 @@ declare module '@ioc:Adonis/Core/Validator' {
      * Before "yesterday" is equivalent to 1, day
      */
     beforeOrEqual(keyword: 'today' | 'yesterday'): Rule
+
+    /**
+     * The value of number must be bigger or equal to minimum.
+     *
+     * @param min the minimum value
+     */
+    minimum(min: number): Rule
   }
 
   /**

--- a/adonis-typings/validator.ts
+++ b/adonis-typings/validator.ts
@@ -1079,6 +1079,13 @@ declare module '@ioc:Adonis/Core/Validator' {
      * @param min the minimum value
      */
     minimum(min: number): Rule
+
+    /**
+     * The value of number must be lower or equal to maximum.
+     *
+     * @param min the minimum value
+     */
+    maximum(min: number): Rule
   }
 
   /**

--- a/src/Validations/index.ts
+++ b/src/Validations/index.ts
@@ -34,6 +34,8 @@ export { notIn } from './miscellaneous/notIn'
 
 export { unsigned } from './number/unsigned'
 export { range } from './number/range'
+export { maximum } from './number/maximum'
+export { minimum } from './number/minimum'
 export { array } from './primitives/array'
 export { boolean } from './primitives/boolean'
 export { date } from './primitives/date'

--- a/src/Validations/number/maximum.ts
+++ b/src/Validations/number/maximum.ts
@@ -1,0 +1,32 @@
+import { SyncValidation } from '@ioc:Adonis/Core/Validator'
+import { wrapCompile } from '../../Validator/helpers'
+
+const RULE_NAME = 'max'
+const DEFAULT_MESSAGE = 'max validation failed'
+
+export const maximum: SyncValidation<{ max: number }> = {
+  compile: wrapCompile(RULE_NAME, ['number'], ([max]) => {
+    if (typeof max !== 'number') {
+      throw new Error(`The min value for "${RULE_NAME}" must be defined as number`)
+    }
+    return {
+      compiledOptions: {
+        max,
+      },
+    }
+  }),
+  validate(value, compiledOptions, { errorReporter, pointer, arrayExpressionPointer }) {
+    if (typeof value !== 'number') {
+      return
+    }
+    if (value > compiledOptions.max) {
+      errorReporter.report(
+        pointer,
+        RULE_NAME,
+        DEFAULT_MESSAGE,
+        arrayExpressionPointer,
+        compiledOptions
+      )
+    }
+  },
+}

--- a/src/Validations/number/minimum.ts
+++ b/src/Validations/number/minimum.ts
@@ -1,0 +1,32 @@
+import { SyncValidation } from '@ioc:Adonis/Core/Validator'
+import { wrapCompile } from '../../Validator/helpers'
+
+const RULE_NAME = 'min'
+const DEFAULT_MESSAGE = 'min validation failed'
+
+export const minimum: SyncValidation<{ min: number }> = {
+  compile: wrapCompile(RULE_NAME, ['number'], ([min]) => {
+    if (typeof min !== 'number') {
+      throw new Error(`The min value for "${RULE_NAME}" must be defined as number`)
+    }
+    return {
+      compiledOptions: {
+        min,
+      },
+    }
+  }),
+  validate(value, compiledOptions, { errorReporter, pointer, arrayExpressionPointer }) {
+    if (typeof value !== 'number') {
+      return
+    }
+    if (value < compiledOptions.min) {
+      errorReporter.report(
+        pointer,
+        RULE_NAME,
+        DEFAULT_MESSAGE,
+        arrayExpressionPointer,
+        compiledOptions
+      )
+    }
+  },
+}

--- a/test/validations/maximum.spec.ts
+++ b/test/validations/maximum.spec.ts
@@ -1,0 +1,76 @@
+import { test } from '@japa/runner'
+import { rules } from '../../src/Rules'
+import { validate } from '../fixtures/rules/index'
+import { MessagesBag } from '../../src/MessagesBag'
+import { ApiErrorReporter } from '../../src/ErrorReporter'
+import { range } from '../../src/Validations/number/range'
+import { maximum } from '../../src/Validations/number/maximum'
+
+function compile(max: number) {
+  return maximum.compile('literal', 'number', rules.maximum(max).options, {})
+}
+
+test.group('max', () => {
+  validate(maximum, test, 3, 1, compile(2))
+
+  test('do not compile when max is not a number', ({ assert }) => {
+    const fn = () => range.compile('literal', 'number', ['10'])
+    assert.throws(fn, 'The start value for "range" must be defined as number')
+  })
+
+  test('report error when value is bigger than the max', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    maximum.validate(11, compile(10).compiledOptions!, {
+      errorReporter: reporter,
+      field: 'price',
+      pointer: 'price',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), {
+      errors: [
+        {
+          field: 'price',
+          rule: 'max',
+          args: {
+            max: 10,
+          },
+          message: 'max validation failed',
+        },
+      ],
+    })
+  })
+
+  test('skip when value is not a number', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    maximum.validate('-10', compile(1).compiledOptions!, {
+      errorReporter: reporter,
+      field: 'price',
+      pointer: 'price',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), { errors: [] })
+  })
+
+  test('work fine when value is a valid number lower than max', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    maximum.validate(25, compile(30).compiledOptions!, {
+      errorReporter: reporter,
+      field: 'age',
+      pointer: 'age',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), { errors: [] })
+  })
+})

--- a/test/validations/maximum.spec.ts
+++ b/test/validations/maximum.spec.ts
@@ -3,7 +3,6 @@ import { rules } from '../../src/Rules'
 import { validate } from '../fixtures/rules/index'
 import { MessagesBag } from '../../src/MessagesBag'
 import { ApiErrorReporter } from '../../src/ErrorReporter'
-import { range } from '../../src/Validations/number/range'
 import { maximum } from '../../src/Validations/number/maximum'
 
 function compile(max: number) {
@@ -14,8 +13,8 @@ test.group('max', () => {
   validate(maximum, test, 3, 1, compile(2))
 
   test('do not compile when max is not a number', ({ assert }) => {
-    const fn = () => range.compile('literal', 'number', ['10'])
-    assert.throws(fn, 'The start value for "range" must be defined as number')
+    const fn = () => maximum.compile('literal', 'number', ['10'])
+    assert.throws(fn, 'The start value for "max" must be defined as number')
   })
 
   test('report error when value is bigger than the max', ({ assert }) => {

--- a/test/validations/minimum.spec.ts
+++ b/test/validations/minimum.spec.ts
@@ -3,7 +3,6 @@ import { rules } from '../../src/Rules'
 import { validate } from '../fixtures/rules/index'
 import { MessagesBag } from '../../src/MessagesBag'
 import { ApiErrorReporter } from '../../src/ErrorReporter'
-import { range } from '../../src/Validations/number/range'
 import { minimum } from '../../src/Validations/number/minimum'
 
 function compile(min: number) {
@@ -14,8 +13,8 @@ test.group('min', () => {
   validate(minimum, test, 0, 2, compile(1))
 
   test('do not compile when min is not a number', ({ assert }) => {
-    const fn = () => range.compile('literal', 'number', ['10'])
-    assert.throws(fn, 'The start value for "range" must be defined as number')
+    const fn = () => minimum.compile('literal', 'number', ['10'])
+    assert.throws(fn, 'The start value for "min" must be defined as number')
   })
 
   test('report error when value is lower than the min', ({ assert }) => {

--- a/test/validations/minimum.spec.ts
+++ b/test/validations/minimum.spec.ts
@@ -1,0 +1,76 @@
+import { test } from '@japa/runner'
+import { rules } from '../../src/Rules'
+import { validate } from '../fixtures/rules/index'
+import { MessagesBag } from '../../src/MessagesBag'
+import { ApiErrorReporter } from '../../src/ErrorReporter'
+import { range } from '../../src/Validations/number/range'
+import { minimum } from '../../src/Validations/number/minimum'
+
+function compile(min: number) {
+  return minimum.compile('literal', 'number', rules.minimum(min).options, {})
+}
+
+test.group('min', () => {
+  validate(minimum, test, 0, 2, compile(1))
+
+  test('do not compile when min is not a number', ({ assert }) => {
+    const fn = () => range.compile('literal', 'number', ['10'])
+    assert.throws(fn, 'The start value for "range" must be defined as number')
+  })
+
+  test('report error when value is lower than the min', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    minimum.validate(0, compile(10).compiledOptions!, {
+      errorReporter: reporter,
+      field: 'price',
+      pointer: 'price',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), {
+      errors: [
+        {
+          field: 'price',
+          rule: 'min',
+          args: {
+            min: 10,
+          },
+          message: 'min validation failed',
+        },
+      ],
+    })
+  })
+
+  test('skip when value is not a number', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    minimum.validate('-10', compile(1).compiledOptions!, {
+      errorReporter: reporter,
+      field: 'price',
+      pointer: 'price',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), { errors: [] })
+  })
+
+  test('work fine when value is a valid number bigger than min', ({ assert }) => {
+    const reporter = new ApiErrorReporter(new MessagesBag({}), false)
+    minimum.validate(25, compile(1).compiledOptions!, {
+      errorReporter: reporter,
+      field: 'age',
+      pointer: 'age',
+      tip: {},
+      root: {},
+      refs: {},
+      mutate: () => {},
+    })
+
+    assert.deepEqual(reporter.toJSON(), { errors: [] })
+  })
+})


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Implementation of the idea behind this issue : https://github.com/adonisjs/validator/issues/169

## Types of changes

Implementing mix and max validators for numbers.

_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/adonisjs/validator/blob/master/.github/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
